### PR TITLE
Wrap command lines in code blocks and add shell prompts.

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -3,14 +3,20 @@ Setup
 
 1. Create a virtual environment
 
-python -m venv .venv
-. .venv/bin/activate
+```
+$ python -m venv .venv
+$ . .venv/bin/activate
+```
 
 2. Install dependencies
 
-pip install pyjwt requests
+```
+$ pip install pyjwt requests
+```
 
 3. Run the script
 
-python kensho_auth.py <clientid> <privatekeyfilename> <scope>
+```
+$ python kensho_auth.py <clientid> <privatekeyfilename> <scope>
+```
 


### PR DESCRIPTION
Example venv instructions run together because markdown ignores
newlines.  Code block (and shell prompts) I think make it a little clearer.